### PR TITLE
Add Release Drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,30 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+categories:
+  - title: "🚀 New Features"
+    labels:
+      - "feature-request"
+      - "enhancement"
+      - "question"
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "bug"
+  - title: "📖 Documentation"
+    label: "documentation"
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - "major"
+  minor:
+    labels:
+      - "minor"
+  patch:
+    labels:
+      - "patch"
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,12 @@
+name: Release Drafter
+on:
+  push:
+    branches:
+      - main
+jobs:
+  draft_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5.20
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nbnpy"
-version = "0.4.1"
+version = "0.5.0"
 description = "Unofficial NBN API wrapper"
 authors = ["Yass"]
 license = "MIT"


### PR DESCRIPTION
## Description of the Change

Adds the release drafter workflow to collect PR's into `main` & auto collate release notes.

## Change Hygiene

Please ensure the following items are complete for all PR's:

- [ ] All CI (`nox`) is passing
- [ ] Documentation appropriately updated
- [ ] Version updated in `pyproject.toml`
