### PR TITLE
Add code copy to code highlighting in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,4 +20,5 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
     "sphinx_autodoc_typehints",
+    "sphinx_copybutton",
 ]

--- a/noxfile.py
+++ b/noxfile.py
@@ -97,5 +97,7 @@ def docs(session: Session) -> None:
         session (Session): Nox Session
     """
     session.run("poetry", "install", external=True)
-    session.install("sphinx", "myst-parser", "sphinx-autodoc-typehints", "furo")
+    session.install(
+        "sphinx", "myst-parser", "sphinx-autodoc-typehints", "furo", "sphinx_copybutton"
+    )
     session.run("sphinx-build", "docs", "docs/_build")

--- a/poetry.lock
+++ b/poetry.lock
@@ -1001,6 +1001,21 @@ sphinx = ">=4.0,<6.0"
 docs = ["furo", "myst-parser", "sphinx-copybutton", "sphinx-inline-tabs", "ipython"]
 
 [[package]]
+name = "sphinx-copybutton"
+version = "0.5.0"
+description = "Add a copy button to each of your code cells."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+sphinx = ">=1.8"
+
+[package.extras]
+code_style = ["pre-commit (==2.12.1)"]
+rtd = ["sphinx", "ipython", "myst-nb", "sphinx-book-theme"]
+
+[[package]]
 name = "sphinxcontrib-applehelp"
 version = "1.0.2"
 description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
@@ -1189,7 +1204,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "2d6a13e370a6e8081eaf4b53bfbfaf889319bb3548e58d0b49cee084c7b40e1e"
+content-hash = "8ea4fba599f5e676b73d6d3c1edbf220b0aea2ccc234a3849125ee970fec330e"
 
 [metadata.files]
 alabaster = [
@@ -1664,6 +1679,10 @@ sphinx-autodoc-typehints = [
 sphinx-basic-ng = [
     {file = "sphinx_basic_ng-0.0.1a11-py3-none-any.whl", hash = "sha256:9aecb5345816998789ef76658a83e3c0a12aafa14b17d40e28cd4aaeb94d1517"},
     {file = "sphinx_basic_ng-0.0.1a11.tar.gz", hash = "sha256:bf9a8fda0379c7d2ab51c9543f2b18e014b77fb295b49d64f3c1a910c863b34f"},
+]
+sphinx-copybutton = [
+    {file = "sphinx-copybutton-0.5.0.tar.gz", hash = "sha256:a0c059daadd03c27ba750da534a92a63e7a36a7736dcf684f26ee346199787f6"},
+    {file = "sphinx_copybutton-0.5.0-py3-none-any.whl", hash = "sha256:9684dec7434bd73f0eea58dda93f9bb879d24bff2d8b187b1f2ec08dfe7b5f48"},
 ]
 sphinxcontrib-applehelp = [
     {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nbnpy"
-version = "0.5.0"
+version = "0.5.1"
 description = "Unofficial NBN API wrapper"
 authors = ["Yass"]
 license = "MIT"
@@ -40,6 +40,7 @@ Sphinx = "4.5"
 myst-parser = "^0.17.2"
 sphinx-autodoc-typehints = "^1.18.2"
 furo = "^2022.6.4"
+sphinx-copybutton = "^0.5.0"
 
 
 [build-system]


### PR DESCRIPTION
## Description of the Change

Adds copy code button to the code highlighting blocks in the docs.


## Change Hygiene

Please ensure the following items are complete for all PR's:

- [x] All CI (`nox`) is passing
- [x] Documentation appropriately updated
- [x] Version updated in `pyproject.toml`
